### PR TITLE
Release 3.1.1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,16 @@
-FROM alpine:3.15
+FROM python:3-alpine
 
+# Current version of s3cmd is in edge/testing repo
+RUN echo https://dl-cdn.alpinelinux.org/alpine/edge/testing >> /etc/apk/repositories
+
+# Install everything via repo because repo & pip installs can break things
 RUN apk update \
  && apk add --no-cache \
             bash \
             postgresql12-client \
-            python3 py-pip \
- && pip install s3cmd python-magic
+            py3-magic \
+            py3-dateutil \
+            s3cmd
 
 COPY application/ /data/
 WORKDIR /data


### PR DESCRIPTION
## Fixes
* Change Docker image base to python:3-alpine.
* Replace the installation of s3cmd via "pip install" to the version in the Alpine  repository.