### PR TITLE
Release 4.0.1 - Use current DB owner during restore

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,6 @@
-FROM python:3-alpine
+# With Python 3.12.4 on Alpine 3.20, s3cmd 2.4.0 fails with an AttributeError.
+# See ITSE-1440 for details.
+FROM python:3.12.3-alpine
 
 # Current version of s3cmd is in edge/testing repo
 RUN echo https://dl-cdn.alpinelinux.org/alpine/edge/testing >> /etc/apk/repositories

--- a/application/restore.sh
+++ b/application/restore.sh
@@ -24,8 +24,14 @@ if [ -z "${result}" ]; then
     message="Database "${DB_NAME}" on host "${DB_HOST}" does not exist."
     echo "${MYNAME}: INFO: ${message}"
 else
+    message="finding current owner of DB ${DB_NAME}"
+    echo "${MYNAME}: ${message}"
+    db_owner=$(psql --host=${DB_HOST} --username=${DB_ROOTUSER} --command='\list' | grep ${DB_NAME} | cut -d '|' -f 2 | sed -e 's/ *//')
+    message="Database owner is ${db_owner}"
+    echo "${MYNAME}: INFO: ${message}"
+
     echo "${MYNAME}: deleting database ${DB_NAME}"
-    result=$(psql --host=${DB_HOST} --dbname=postgres --username=${DB_USER} --command="DROP DATABASE ${DB_NAME};")
+    result=$(psql --host=${DB_HOST} --dbname=postgres --username=${db_owner} --command="DROP DATABASE ${DB_NAME};")
     if [ "${result}" != "DROP DATABASE" ]; then
         message="Drop database command failed: ${result}"
         echo "${MYNAME}: FATAL: ${message}"

--- a/application/restore.sh
+++ b/application/restore.sh
@@ -26,7 +26,7 @@ if [ -z "${result}" ]; then
 else
     message="finding current owner of DB ${DB_NAME}"
     echo "${MYNAME}: ${message}"
-    db_owner=$(psql --host=${DB_HOST} --username=${DB_ROOTUSER} --command='\list' | grep ${DB_NAME} | cut -d '|' -f 2 | sed -e 's/ *//')
+    db_owner=$(psql --host=${DB_HOST} --username=${DB_ROOTUSER} --command='\list' | grep ${DB_NAME} | cut -d '|' -f 2 | sed -e 's/ *//g')
     message="Database owner is ${db_owner}"
     echo "${MYNAME}: INFO: ${message}"
 


### PR DESCRIPTION
### Changes
* Constrain Python version to 3.12.3.  `s3cmd` version 2.4.0 with Python 3.12.4 on Alpine 3.20 fails with an `AttributeError`.
* Find and use the current database owner when dropping the database during a restore operation.
