### PR TITLE
Fix for Python 3.12.3 constrained

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # With Python 3.12.4 on Alpine 3.20, s3cmd 2.4.0 fails with an AttributeError.
 # See ITSE-1440 for details.
-FROM python:3.12.3-alpine
+FROM python:3.12.4-alpine
 
 # Current version of s3cmd is in edge/testing repo
 RUN echo https://dl-cdn.alpinelinux.org/alpine/edge/testing >> /etc/apk/repositories
@@ -12,10 +12,15 @@ RUN apk update \
             postgresql14-client \
             py3-magic \
             py3-dateutil \
-            s3cmd \
             curl \
-            jq
-
+            jq 
+            
+RUN wget https://github.com/s3tools/s3cmd/archive/refs/tags/v2.4.0.tar.gz \
+            && tar xzf v2.4.0.tar.gz \
+            && cd s3cmd-2.4.0 \
+            && python setup.py install \
+            && cd .. \
+            && rm -rf s3cmd-2.4.0 v2.4.0.tar.gz
 # Install sentry-cli
 RUN curl -sL https://sentry.io/get-cli/ | bash
 


### PR DESCRIPTION
### Fixed 

- Encountered a compatibility issue with the datetime module while installing s3cmd, indicating the use of an older version.
- Decided to install s3cmd from the source to ensure the latest version is used.
- The source installation pulls the latest fixes from GitHub, which may not be available in package manager releases.
- Tested the installation locally in a Docker container, and it worked without issues.
