### PR TITLE
remove s3:// S3_BUCKET prefix added in error

### DIFF
--- a/application/backup.sh
+++ b/application/backup.sh
@@ -146,7 +146,7 @@ if [ "${B2_BUCKET}" != "" ]; then
     start=$(date +%s);
     AWS_ACCESS_KEY_ID="${B2_APPLICATION_KEY_ID}" \
     AWS_SECRET_ACCESS_KEY="${B2_APPLICATION_KEY}" \
-    aws s3 cp "/tmp/${DB_NAME}.sql.gz" "${B2_BUCKET}/${DB_NAME}.sql.gz" \
+    aws s3 cp "/tmp/${DB_NAME}.sql.gz" "s3://${B2_BUCKET}/${DB_NAME}.sql.gz" \
       --endpoint-url "https://${B2_HOST}"
     STATUS=$?;
     end=$(date +%s);

--- a/application/backup.sh
+++ b/application/backup.sh
@@ -121,7 +121,7 @@ fi
 
 # Upload compressed backup file to S3
 start=$(date +%s);
-aws s3 cp "/tmp/${DB_NAME}.sql.gz" "s3://${S3_BUCKET}/${DB_NAME}.sql.gz" || STATUS=$?
+aws s3 cp "/tmp/${DB_NAME}.sql.gz" "${S3_BUCKET}/${DB_NAME}.sql.gz" || STATUS=$?
 if [ $STATUS -ne 0 ]; then
     error_message="${MYNAME}: FATAL: Copy backup to ${S3_BUCKET} of ${DB_NAME} returned non-zero status ($STATUS) in $(expr ${end} - ${start}) seconds.";
     log "ERROR" "${error_message}";
@@ -130,7 +130,7 @@ if [ $STATUS -ne 0 ]; then
 fi
 
 # Upload checksum file
-aws s3 cp "/tmp/${DB_NAME}.sql.sha256.gz" "s3://${S3_BUCKET}/${DB_NAME}.sql.sha256.gz" || STATUS=$?;
+aws s3 cp "/tmp/${DB_NAME}.sql.sha256.gz" "${S3_BUCKET}/${DB_NAME}.sql.sha256.gz" || STATUS=$?;
 end=$(date +%s);
 if [ $STATUS -ne 0 ]; then
     error_message="${MYNAME}: FATAL: Copy checksum to ${S3_BUCKET} of ${DB_NAME} returned non-zero status ($STATUS).";
@@ -146,7 +146,7 @@ if [ "${B2_BUCKET}" != "" ]; then
     start=$(date +%s);
     AWS_ACCESS_KEY_ID="${B2_APPLICATION_KEY_ID}" \
     AWS_SECRET_ACCESS_KEY="${B2_APPLICATION_KEY}" \
-    aws s3 cp "/tmp/${DB_NAME}.sql.gz" "s3://${B2_BUCKET}/${DB_NAME}.sql.gz" \
+    aws s3 cp "/tmp/${DB_NAME}.sql.gz" "${B2_BUCKET}/${DB_NAME}.sql.gz" \
       --endpoint-url "https://${B2_HOST}"
     STATUS=$?;
     end=$(date +%s);

--- a/application/restore.sh
+++ b/application/restore.sh
@@ -95,7 +95,7 @@ log "INFO" "${MYNAME}: copying database ${DB_NAME} backup and checksum from ${S3
 start=$(date +%s)
 
 # Download database backup
-aws s3 cp s3://${S3_BUCKET}/${DB_NAME}.sql.gz /tmp/${DB_NAME}.sql.gz || STATUS=$?
+aws s3 cp "${S3_BUCKET}/${DB_NAME}.sql.gz" "/tmp/${DB_NAME}.sql.gz" || STATUS=$?
 if [ $STATUS -ne 0 ]; then
     error_message="${MYNAME}: FATAL: Copy backup of ${DB_NAME} from ${S3_BUCKET} returned non-zero status ($STATUS) in $(expr $(date +%s) - ${start}) seconds."
     log "ERROR" "${error_message}"
@@ -104,7 +104,7 @@ if [ $STATUS -ne 0 ]; then
 fi
 
 # Download checksum file
-aws s3 cp s3://${S3_BUCKET}/${DB_NAME}.sql.sha256.gz /tmp/${DB_NAME}.sql.sha256.gz || STATUS=$?
+aws s3 cp "${S3_BUCKET}/${DB_NAME}.sql.sha256.gz" "/tmp/${DB_NAME}.sql.sha256.gz" || STATUS=$?
 end=$(date +%s)
 if [ $STATUS -ne 0 ]; then
     error_message="${MYNAME}: FATAL: Copy checksum of ${DB_NAME} from ${S3_BUCKET} returned non-zero status ($STATUS) in $(expr ${end} - ${start}) seconds."


### PR DESCRIPTION
### Fixed
- Fix a bug introduced in version 5.1.2, where the `s3://` prefix was added to the `S3_BUCKET`, which is already expected to have it.