### PR TITLE
Add `--quiet` to the second `aws s3 cp` command (copy to B2)

### DIFF
--- a/application/backup.sh
+++ b/application/backup.sh
@@ -4,7 +4,7 @@
 log() {
     local level="$1";
     local message="$2";
-    echo "[$(date '+%Y-%m-%d %H:%M:%S')] ${level}: ${MYNAME}: ${message}";
+    echo "[$(date '+%Y-%m-%d %H:%M:%S')] ${MYNAME}: ${level}: ${message}";
 }
 
 # Function to remove sensitive values from sentry Event
@@ -150,7 +150,7 @@ if [ "${B2_BUCKET}" != "" ]; then
     start=$(date +%s);
     AWS_ACCESS_KEY_ID="${B2_APPLICATION_KEY_ID}" \
     AWS_SECRET_ACCESS_KEY="${B2_APPLICATION_KEY}" \
-    aws s3 cp "/tmp/${DB_NAME}.sql.gz" "s3://${B2_BUCKET}/${DB_NAME}.sql.gz" \
+    aws s3 cp --quiet "/tmp/${DB_NAME}.sql.gz" "s3://${B2_BUCKET}/${DB_NAME}.sql.gz" \
       --endpoint-url "https://${B2_HOST}"
     STATUS=$?;
     end=$(date +%s);

--- a/application/restore.sh
+++ b/application/restore.sh
@@ -4,7 +4,7 @@
 log() {
     local level="$1"
     local message="$2"
-    echo "[$(date '+%Y-%m-%d %H:%M:%S')] ${level}: ${MYNAME}: ${message}"
+    echo "[$(date '+%Y-%m-%d %H:%M:%S')] ${MYNAME}: ${level}: ${message}"
 }
 
 filter_sensitive_values() {


### PR DESCRIPTION
Add `--quiet` to the second `aws s3 cp` command (copy to B2) and flip the order of `${MYNAME}` and `${level}` to make the log lines even more tidy. MYNAME is always the same length, but level can be different lengths.