### PR TITLE
Update base image to Python 3.12-alpine3.21 in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.12.4-alpine
+FROM python:3.12-alpine3.21
 
 RUN <<EOF
   apk update


### PR DESCRIPTION
Changed 

Update base image to Python 3.12-alpine3.21 in Dockerfile. As the older version doesn't have postgresql-client17  